### PR TITLE
Various fixes

### DIFF
--- a/insert-shebang.el
+++ b/insert-shebang.el
@@ -1,4 +1,4 @@
-;;; insert-shebang.el --- Inserts shebang line automatically -*- lexical-binding: t; -*-
+;;; insert-shebang.el --- Inserts shebang line automatically
 
 ;; Copyright (C) 2013  Sachin Patil
 
@@ -6,7 +6,6 @@
 ;; URL: http://github.com/psachin/insert-shebang
 ;; Keywords: tools, convenience
 ;; Version: 0.9.1
-;; Package-Requires: None
 
 ;; This file is NOT a part of GNU Emacs.
 
@@ -17,26 +16,31 @@
 ;;; Commentary:
 ;; Inserts shebang line automatically
 
-;;; Install
-;; (load "~/.emacs.d/insert-shebang.el")
+;; Install
+;;
+;; Unless installed from a package, add the directory containing
+;; this file to `load-path', and then:
+;; (require 'insert-shebang)
+;;
+;; Then enable it globally using:
+;;
+;; (add-hook 'find-file-hook 'insert-shebang)
 
 ;;; Code:
 
 (defgroup insert-shebang nil
   "Inserts shebang line automatically"
   :group 'extensions
-  :link '(url-link :tag "Github" "https://github.com/psachin/insert-shebang")
-  )
+  :link '(url-link :tag "Github" "https://github.com/psachin/insert-shebang"))
 
 (defcustom insert-shebang-flag nil
   "*If non-nil, add the root directory to the load path."
   :type 'boolean
-  :group 'example)
+  :group 'insert-shebang)
 
-(defun get-extension-and-insert(filename)
+(defun get-extension-and-insert (filename)
   "Get extension from FILENAME and insert shebang.
 FILENAME is a buffer name from which the extension in extracted."
-
   (interactive "*")
   (let (myInterpreter val)
      
@@ -87,18 +91,15 @@ FILENAME is a buffer name from which the extension in extracted."
 		  )))))
       ;; if key don't exists
       (progn
-	(message "Can't guess file type"))
-      )))
+	(message "Can't guess file type")))))
 
-(defun insert-shebang()
+;;;###autoload
+(defun insert-shebang ()
   "Calls get-get-extension-and-insert with argument as
 buffer-name"
   (interactive "*")
   (get-extension-and-insert(buffer-name)))
 
-;; create hook
-(add-hook 'find-file-hook 'insert-shebang)
-;; (remove-hook 'find-file-hook 'insert-shebang)
 
 (provide 'insert-shebang)
 ;;; insert-shebang.el ends here


### PR DESCRIPTION
I saw this library pop up on Marmalade, and I plan to add it to [MELPA](http://melpa.milkbox.net/).

This commit provides the following fixes:
- Remove activation lexical-binding, which is not used, and would limit the package to Emacs 24 only
- Fix doc formatting, recommend require instead of load
- Remove malformatted Package-Requires line
- Autoload insert-shebang function
- Don't modify find-file-hook directly: this is bad practice
- Fix custom group

Really, though, you should provide a `defcustom` which is an alist from major mode to interpreter name. The hard-coded hash table is a bit of a hack which limits the usefulness of the code.

Cheers!

-Steve
